### PR TITLE
Fix Linux Builds

### DIFF
--- a/prepare_debug.sh
+++ b/prepare_debug.sh
@@ -6,7 +6,7 @@ case "$OSTYPE" in
     export BDF=$(pwd)/bin/Debug/net48
     ;; 
   linux*)
-    export GMF=$HOME/Games/steam/worldbox/worldbox_Data/StreamingAssets/Mods
+    export GMF=$HOME/.local/share/Steam/steamapps/common/worldbox/worldbox_Data/StreamingAssets/mods/
     export BDF=$(pwd)/bin/Debug/net48
     ;;
 esac


### PR DESCRIPTION
The default installation of WorldBox Mods on Linux is located under `$HOME/.local/share/Steam/steamapps/common/worldbox/worldbox_Data/StreamingAssets/mods/`. Not `$HOME/Games/steam/worldbox/worldbox_Data/StreamingAssets/Mods`.

Moreover, it's probably better to just ask the user where the directory is located. As some distros may disobey the default path configuration.