### PR TITLE
1 character fix that somehow fixes localization for NCMS buttons 

### DIFF
--- a/ncms_compatible_layer/NCMS/Utils/PowerButtons.cs
+++ b/ncms_compatible_layer/NCMS/Utils/PowerButtons.cs
@@ -23,7 +23,7 @@ namespace NCMS.Utils
             Transform parent = null, UnityAction call = null)
         {
             LM.AddToCurrentLocale(name, title);
-            LM.AddToCurrentLocale(name + " Description", description);
+            LM.AddToCurrentLocale(name + " description", description);
             LM.ApplyLocale(false);
             PowerButton asPowerButton;
             switch (type)


### PR DESCRIPTION
ModernBox still uses the NCMS way so I fixed this (somehow)