### PR TITLE
Bugfix: Sync missing JSON field RepoUrl in ModDeclare constructor

### DIFF
--- a/api/ModDeclare.cs
+++ b/api/ModDeclare.cs
@@ -115,6 +115,7 @@ public class ModDeclare
         IncompatibleWith = modDeclare.IncompatibleWith;
         ModType = modDeclare.ModType;
         UsePublicizedAssembly = modDeclare.UsePublicizedAssembly;
+        RepoUrl = modDeclare.RepoUrl;
 
         Dependencies ??= Array.Empty<string>();
         OptionalDependencies ??= Array.Empty<string>();


### PR DESCRIPTION
Fixed the `RepoUrl` in `mod.json` was nerver loaded.