### PR TITLE
Fix startup NullReferenceException on WorldBox 0.51.2 (resilient power-tab lookup)

### DIFF
--- a/general/PowerButtonCreator.cs
+++ b/general/PowerButtonCreator.cs
@@ -278,10 +278,23 @@ public static class PowerButtonCreator
     public static PowersTab GetTab(string pId)
     {
         if (string.IsNullOrEmpty(pId)) return null;
+
+        // Fast path (valid up to 0.51.0): hard-coded UI hierarchy lookup.
         Transform tabTransform = CanvasMain.instance.canvas_ui.transform.Find(
             $"CanvasBottom/BottomElements/BottomElementsMover/CanvasScrollView/Scroll View/Viewport/Content/Power Tabs/{pId}");
+        if (tabTransform != null)
+        {
+            var found = tabTransform.GetComponent<PowersTab>();
+            if (found != null) return found;
+        }
 
-        return tabTransform == null ? null : tabTransform.GetComponent<PowersTab>();
+        // Fallback (0.51.1+): the hierarchy moved. Locate the tab by its object name.
+        foreach (var tab in Resources.FindObjectsOfTypeAll<PowersTab>())
+        {
+            if (tab != null && tab.name == pId) return tab;
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/general/ui/tab/WrappedPowersTab.cs
+++ b/general/ui/tab/WrappedPowersTab.cs
@@ -25,15 +25,23 @@ internal class WrappedPowersTab
     {
         Tab = pPowersTab;
 
-        Modifiable = !PowerTabNames.GetNames().Contains(Tab.name);
-
         ButtonGroups = new();
         CustomRectGroups = new();
 
-        AddGroup("Default");
-
         _inactive_lines = new();
         _active_lines = new();
+
+        if (Tab == null)
+        {
+            // Tab not found (e.g. hierarchy changed in a newer WorldBox build):
+            // don't NRE, just leave this wrapper inert.
+            Modifiable = false;
+            return;
+        }
+
+        Modifiable = !PowerTabNames.GetNames().Contains(Tab.name);
+
+        AddGroup("Default");
     }
 
     internal void RecordLine(GameObject line)


### PR DESCRIPTION
## Problem

On WorldBox **0.51.2** (build 719@5dec), starting the game with mods enabled crashes during NML's vanilla-tab reconstruction:

```
System.NullReferenceException: Object reference not set to an instance of an object
  at NeoModLoader.General.UI.Tab.WrappedPowersTab..ctor (PowersTab pPowersTab) [0x00015]
  at NeoModLoader.General.UI.Tab.TabMain.InitTab ()
  at NeoModLoader.General.UI.Tab.ReconstructedVanillaTab.Init ()
  at NeoModLoader.General.UI.Tab.TabManager._init ()
```

## Root cause

`PowerButtonCreator.GetTab(pId)` locates the tab through a hard-coded UI hierarchy path:

```
CanvasBottom/BottomElements/BottomElementsMover/CanvasScrollView/Scroll View/Viewport/Content/Power Tabs/{pId}
```

In 0.51.2 this hierarchy changed, so `transform.Find(...)` returns `null`, `GetTab` returns `null`, and `new WrappedPowersTab(null)` throws an NRE on `Tab.name`.

## Changes

1. **`general/PowerButtonCreator.cs` — `GetTab`**: keep the fast hard-coded path, but fall back to locating the tab by its GameObject name via `Resources.FindObjectsOfTypeAll<PowersTab>()` when the path no longer matches. This makes the lookup resilient to UI-hierarchy changes.
2. **`general/ui/tab/WrappedPowersTab.cs` — constructor**: add a null guard so the wrapper never NREs even if a tab is still not found (sets `Modifiable = false` and returns early).

## Testing

Built in Debug and tested in-game on WorldBox **0.51.2** (experimental):
- no more `WrappedPowersTab..ctor` NRE at boot,
- power tabs reconstruct correctly,
- vanilla + modded power buttons present.